### PR TITLE
Update Bowser to 2.7.0

### DIFF
--- a/browser-detection/BrowserDetection.js
+++ b/browser-detection/BrowserDetection.js
@@ -186,7 +186,7 @@ export default class BrowserDetection {
             version = undefined;
         }
 
-        this._name = name.toLowerCase();
+        this._name = name;
         this._version = version;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -232,9 +232,9 @@
       "dev": true
     },
     "bowser": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.1.tgz",
-      "integrity": "sha512-UXti1JB6oK8hO983AImunnV6j/fqAEeDlPXh99zhsP5g32oLbxJJ6qcOaUesR+tqqhnUVQHlRJyD0dfiV0Hxaw=="
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.7.0.tgz",
+      "integrity": "sha512-aIlMvstvu8x+34KEiOHD3AsBgdrzg6sxALYiukOWhFvGMbQI6TRP/iY0LMhUrHs56aD6P1G0Z7h45PUJaa5m9w=="
     },
     "brace-expansion": {
       "version": "1.1.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "author": "",
   "readmeFilename": "README.md",
   "dependencies": {
-    "bowser": "1.9.1",
+    "bowser": "2.7.0",
     "js-md5": "0.7.3",
     "postis": "2.2.0"
   },


### PR DESCRIPTION
- Update the Bowser package to 2.7.0.
- This is a breaking change as `CompareVersions` API is no longer available. Use `satisfies` to check if the parsed browser matches the condition.
