### PR TITLE
feat(BrowserDetection): do not use window.chrome to identify Chromium…

### DIFF
--- a/browser-detection/BrowserDetection.js
+++ b/browser-detection/BrowserDetection.js
@@ -28,9 +28,9 @@ const bowserNameToJitsiName = {
 /**
  * Detects a Chromium based environent.
  *
- * NOTE: Here we cannot check solely for "Chrome" in the UA string and the
- * "window.chrome" property, because Edge has both. We need to check explicitly
- * for chromium based Edge first and then detect other chromium based browsers.
+ * NOTE: Here we cannot check solely for "Chrome" in the UA, because Edge has
+ * it too. We need to check explicitly for chromium based Edge first and then
+ * detect other chromium based browsers.
  *
  * @returns {Object|undefined} - The name (CHROME) and version.
  */
@@ -41,7 +41,7 @@ function _detectChromiumBased() {
         version: undefined
     };
 
-    if (Boolean(window.chrome) && userAgent.match(/Chrome/)) {
+    if (userAgent.match(/Chrome/)) {
         if (userAgent.match(/Edg/)) {
             const version = userAgent.match(/Edg\/([\d.]+)/)[1];
 


### PR DESCRIPTION
…-like browsers (#20)

webOS (and maybe other web runtimes) may be based on Chromium, but that does
not imply it exposes window.chrome API. So checking window.chrome is
currently breaking Jitsi on them.

This PR just removes the window.chrome check.