### PR TITLE
fix(browser-detection): detect old Edge versions and mark them as unsupported

### DIFF
--- a/browser-detection/BrowserDetection.js
+++ b/browser-detection/BrowserDetection.js
@@ -41,7 +41,7 @@ function _detectChromiumBased() {
         version: undefined
     };
 
-    if (userAgent.match(/Chrome/)) {
+    if (userAgent.match(/Chrome/) && !userAgent.match(/Edge/)) {
         if (userAgent.match(/Edg/)) {
             const version = userAgent.match(/Edg\/([\d.]+)/)[1];
 


### PR DESCRIPTION
new Edge (default): 
==============
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3763.0 Safari/537.36 Edg/75.0.131.0

old Edge (white lie): 
===============
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/18.17763

Make sure we return browser name as 'UNKNOWN' for older Edge versions.