### PR TITLE
feat(browser-detect) try to detect Electron without the UA string

### DIFF
--- a/browser-detection/BrowserDetection.js
+++ b/browser-detection/BrowserDetection.js
@@ -75,6 +75,11 @@ function _detectElectron() {
             name: ELECTRON,
             version
         };
+    } else if (typeof window.JitsiMeetElectron !== 'undefined') {
+        return {
+            name: ELECTRON,
+            version: undefined
+        };
     }
 }
 


### PR DESCRIPTION
If an app has overwritten the UA string we won't be able to tell it's
electron. Try harder by checking if an object we expose is there.