### PR TITLE
changed js-MD5 to spark-MD5

### DIFF
--- a/avatar/index.ts
+++ b/avatar/index.ts
@@ -1,4 +1,4 @@
-import md5 from 'js-md5';
+import md5 from 'spark-md5'; // swaped
 
 /**
  * Returns the Gravatar URL of a given email id.
@@ -11,7 +11,7 @@ export function getGravatarURL(key: string, baseURL: string = 'https://www.grava
     const urlSuffix = '?d=404&size=200';
 
     // If the key is a valid email, we hash it. If it's not, we assume it's already a hashed format.
-    const avatarKey: string = isValidEmail(key) ? md5.hex(key.trim().toLowerCase()) : key;
+    const avatarKey: string = isValidEmail(key) ? md5.hash(key.trim().toLowerCase()) : key;  // there is used hex before now is hash
 
     return `${baseURL}${avatarKey}${urlSuffix}`;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@hapi/bourne": "3.0.0",
-        "js-md5": "0.7.3",
+        "spark-md5": "^3.0.2",
         "ua-parser-js": "1.0.35"
       },
       "devDependencies": {
@@ -20,6 +20,7 @@
         "@types/chai": "5.2.3",
         "@types/js-md5": "0.8.0",
         "@types/node": "24.9.2",
+        "@types/spark-md5": "^3.0.5",
         "@types/ua-parser-js": "0.7.39",
         "@typescript-eslint/eslint-plugin": "8.46.2",
         "@typescript-eslint/parser": "8.46.2",
@@ -2012,6 +2013,13 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/spark-md5": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
+      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ua-parser-js": {
       "version": "0.7.39",
@@ -6463,12 +6471,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "node_modules/js-md5": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
-      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ==",
-      "license": "MIT"
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8421,6 +8423,12 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
@@ -10690,6 +10698,12 @@
           }
         }
       }
+    },
+    "@types/spark-md5": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/spark-md5/-/spark-md5-3.0.5.tgz",
+      "integrity": "sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==",
+      "dev": true
     },
     "@types/ua-parser-js": {
       "version": "0.7.39",
@@ -13616,11 +13630,6 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
-    "js-md5": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/js-md5/-/js-md5-0.7.3.tgz",
-      "integrity": "sha512-ZC41vPSTLKGwIRjqDh8DfXoCrdQIyBgspJVPXHBGu4nZlAEvG3nf+jO9avM9RmLiGakg7vz974ms99nEV0tmTQ=="
-    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14940,6 +14949,11 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
       "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "dev": true
+    },
+    "spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "spdx-exceptions": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "@hapi/bourne": "3.0.0",
-    "js-md5": "0.7.3",
+    "spark-md5": "^3.0.2",
     "ua-parser-js": "1.0.35"
   },
   "devDependencies": {
@@ -23,8 +23,8 @@
     "@jitsi/eslint-config": "6.0.4",
     "@rollup/plugin-commonjs": "^29.0.0",
     "@types/chai": "5.2.3",
-    "@types/js-md5": "0.8.0",
     "@types/node": "24.9.2",
+    "@types/spark-md5": "^3.0.5",
     "@types/ua-parser-js": "0.7.39",
     "@typescript-eslint/eslint-plugin": "8.46.2",
     "@typescript-eslint/parser": "8.46.2",


### PR DESCRIPTION
Added spark-md5 dependency and types

Description:
Added the spark-md5 library for MD5 hashing functionality along with its TypeScript type definitions to improve development experience and type safety.

Changes:

Added spark-md5 to dependencies
Added @types/spark-md5 to devDependencies

Why:

Enables efficient MD5 hashing in the project
Improves type safety and IntelliSense support in TypeScript

Updated package.json:

"dependencies": {
  "spark-md5": "^3.0.2"
},
"devDependencies": {
  "@types/spark-md5": "^3.0.5"
}