### PR TITLE
ci(release): migrate publish to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,4 +1,4 @@
-name: "AutoPublish"
+name: "Bump version"
 
 on:
   push:
@@ -6,8 +6,8 @@ on:
       - "master"
 
 jobs:
-  auto-publish:
-    name: "AutoPublish on master"
+  bump:
+    name: "Bump version on master"
     runs-on: ubuntu-latest
     if: "!startsWith(github.event.head_commit.message, 'chore: bump version to')"
 
@@ -19,7 +19,7 @@ jobs:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: "Checkout source code"
-        uses: "actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd"  # v5
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"  # v6.0.2
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: "Automated Release"
@@ -28,12 +28,3 @@ jobs:
           commit-message: 'chore: bump version to {{version}}'
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
-        with:
-          node-version: '18'
-          registry-url: 'https://registry.npmjs.org'
-      - name: "Install dependencies"
-        run: npm install
-      - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: "Publish to npm"
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  publish:
+    name: "Publish to npm"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm test
+      - run: npm publish --access public


### PR DESCRIPTION
## Summary
- Replaces broken `NPM_AUTH_TOKEN` (auth-failing since 2025-11) with npm Trusted Publishing via GitHub Actions OIDC. No long-lived secret, short-lived per-run credentials, automatic provenance attestations.
- Splits `autopublish.yml` into `bump.yml` (master push → version bump + tag) and `publish.yml` (tag push → tests + publish). Only `publish.yml` holds `id-token: write`.
- Adds `npm test` as a release gate inside `publish.yml`.
- Bumps `actions/checkout` v5 → v6.0.2 and `actions/setup-node` v6.3.0 → v6.4.0 (latest minors in v6.x).
- Bumps Node 18 → 24 (Trusted Publishing requires npm ≥ 11.5.1, which ships with Node ≥ 22.14; 24 matches the npm docs example and is current).
- Switches `npm install` → `npm ci` in the publish path for deterministic installs.
- Adds `package-manager-cache: false` per the npm docs guidance ("never use caching in release builds").

## Why
Versions 6.2.1, 6.2.2, 6.2.3, and 6.3.0 were bumped on master but never published — `npm publish` has been failing with `404 Not Found` (npm's stand-in for "auth failed" on a scoped package) since 2025-11. The shared `NPM_AUTH_TOKEN` was last rotated in July 2022 and is no longer valid. Rotating it again puts us right back on the same time-bomb.

## Required action before merge
A Trusted Publisher must be configured on npmjs.com for `@jitsi/js-utils`:
- **Organization or user**: `jitsi`
- **Repository**: `js-utils`
- **Workflow filename**: `publish.yml`
- **Environment name**: (leave blank)

Without this, `publish.yml` will fail at the OIDC token-exchange step.

## After merge
1. Master push triggers `bump.yml` → bumps to next version, pushes tag.
2. Tag push triggers `publish.yml` → runs `npm test`, then `npm publish` via OIDC.
3. Verify with `npm view @jitsi/js-utils version` (should leave `6.2.0`).
4. Delete the unused secret: `gh secret delete NPM_AUTH_TOKEN --repo jitsi/js-utils`.

## Test plan
- [ ] Configure Trusted Publisher on npmjs.com before merge
- [ ] After merge, watch `bump.yml` push the next version tag
- [ ] Watch `publish.yml` run on the tag, succeed at `npm test` and `npm publish`
- [ ] Confirm new version on npm registry
- [ ] Confirm Provenance section appears on the package page
- [ ] Delete `NPM_AUTH_TOKEN` secret