### PR TITLE
fix(package): correct subpath export resolution for all module types

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,17 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./json": {
+      "types": "./dist/json.d.ts",
+      "default": "./dist/json.js"
+    },
+    "./polyfills/*": {
+      "types": "./dist/polyfills/*.d.ts",
+      "default": "./dist/polyfills/*.js"
+    },
     "./*": {
-      "types": "./dist/*",
-      "default": "./dist/*"
+      "types": "./dist/*/index.d.ts",
+      "default": "./dist/*/index.js"
     }
   },
   "files": [


### PR DESCRIPTION
## Summary
- Fix the subpath exports in `package.json` so all documented import paths resolve correctly. The previous wildcard mapped `./*` to `./dist/*` without extensions, which prevented Node's ESM resolver and bundlers from locating the actual built files.
- The package contains modules with three different layouts, so a single wildcard can't cover them all:
  - **Directory modules** (`avatar`, `browser-detection`, `jitsi-local-storage`, `random`, `transport`) expose an `index` file. The wildcard `./*` now maps to `./dist/*/index.js` and `./dist/*/index.d.ts`.
  - **Single-file `json` module** lives at the package root, so add an explicit `./json` export pointing at `./dist/json.js` / `./dist/json.d.ts`.
  - **`polyfills/`** exposes individual files rather than a barrel, so add a dedicated `./polyfills/*` wildcard that maps each name to `./dist/polyfills/*.js` / `./dist/polyfills/*.d.ts`.

## Test plan
- [ ] `npm run build` succeeds.
- [ ] Import a directory-module subpath (e.g. `import { randomHexString } from '@jitsi/js-utils/random'`) and verify it resolves to `dist/random/index.js` with matching `.d.ts` types.
- [ ] `import { safeJsonParse } from '@jitsi/js-utils/json'` resolves to `dist/json.js`.
- [ ] Importing an individual polyfill (e.g. `@jitsi/js-utils/polyfills/<name>`) resolves to the matching file under `dist/polyfills/`.
- [ ] Main entry import (`@jitsi/js-utils`) still works unchanged.