### PR TITLE
fix(ci): declare token permissions so dependabot PR test checks can be created

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,10 @@ jobs:
 
     - name: Create test results check
       if: always() && github.event_name == 'pull_request'
+      # Fork PRs run with a read-only token that permissions can't elevate;
+      # this reporting step must not fail the job when check creation is
+      # rejected, since the results are also in the step summary.
+      continue-on-error: true
       uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
       with:
         script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [master, main]
   pull_request:
 
+# Dependabot-triggered runs get a read-only GITHUB_TOKEN unless permissions are
+# declared explicitly, which made the check-runs API call in the test job fail.
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -26,6 +31,11 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # The "Create test results check" step posts to the check-runs API, which
+    # needs checks:write.
+    permissions:
+      contents: read
+      checks: write
     steps:
     - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
 


### PR DESCRIPTION
## Summary

Every open dependabot PR currently fails the **Test** job even though all tests pass (126/126, 100% coverage). The job fails at the "Create test results check" step: dependabot-triggered workflow runs receive a read-only `GITHUB_TOKEN` because the workflow declares no `permissions` block, so the `POST /check-runs` call (which requires `checks: write`) is rejected with 403 "Resource not accessible by integration" and the unhandled error marks the whole job failed. Lint and Build pass because they make no GitHub API calls; master is green because push events skip the step.

Two changes:

1. **Declare explicit least-privilege token permissions** — `contents: read` at the workflow level, plus `checks: write` on the test job only. GitHub honors an explicit `permissions` key for same-repo dependabot runs ([docs](https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/dependabot-on-actions)), which is what makes the dependabot PRs green again.
2. **Make the check-creation step `continue-on-error`** — fork PRs always run with a read-only token that no `permissions` block can elevate, and this reporting step must not fail the Test job on a green test run. Real test failures are unaffected: the "Generate test summary" step independently re-raises the test exit code, and the results also land in the step summary. The "Test Results" check is not a required status check (verified against the repo ruleset), so skipping it can't block merges.

## Test plan

- YAML validated with js-yaml; permissions semantics verified against current GitHub docs (job-level `permissions` replaces workflow-level, hence `contents: read` is re-declared on the test job).
- This PR's own CI run exercises the workflow on a `pull_request` event with the new permissions.
- The dependabot-specific behavior can only be exercised after merge: re-trigger the open dependabot PRs (e.g. `@dependabot rebase`) so their runs pick up the updated workflow from master, and confirm the Test job goes green.