### PR TITLE
fix(deps): revert ua-parser-js to MIT-licensed 1.0.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hapi/bourne": "3.0.0",
         "js-md5": "0.7.3",
-        "ua-parser-js": "2.0.10"
+        "ua-parser-js": "1.0.35"
       },
       "devDependencies": {
         "@esm-bundle/chai": "4.3.4",
@@ -2590,32 +2590,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/dev-server-esbuild/node_modules/ua-parser-js": {
-      "version": "1.0.41",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
-      "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        }
-      ],
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@web/dev-server-rollup": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/@web/dev-server-rollup/-/dev-server-rollup-0.6.4.tgz",
@@ -4098,25 +4072,6 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
-    },
-    "node_modules/detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1508733",
@@ -6307,25 +6262,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -9075,29 +9011,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ]
-    },
     "node_modules/ua-parser-js": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
-      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -9106,20 +9023,9 @@
         {
           "type": "paypal",
           "url": "https://paypal.me/faisalman"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/faisalman"
         }
       ],
-      "dependencies": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      },
-      "bin": {
-        "ua-parser-js": "script/cli.js"
-      },
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -11166,14 +11072,6 @@
         "esbuild": "^0.25.0",
         "parse5": "^6.0.1",
         "ua-parser-js": "^1.0.33"
-      },
-      "dependencies": {
-        "ua-parser-js": {
-          "version": "1.0.41",
-          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.41.tgz",
-          "integrity": "sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==",
-          "dev": true
-        }
       }
     },
     "@web/dev-server-rollup": {
@@ -12150,11 +12048,6 @@
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true
-    },
-    "detect-europe-js": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/detect-europe-js/-/detect-europe-js-0.1.2.tgz",
-      "integrity": "sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow=="
     },
     "devtools-protocol": {
       "version": "0.0.1508733",
@@ -13640,11 +13533,6 @@
       "requires": {
         "call-bound": "^1.0.3"
       }
-    },
-    "is-standalone-pwa": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-standalone-pwa/-/is-standalone-pwa-0.1.1.tgz",
-      "integrity": "sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g=="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -15500,20 +15388,10 @@
       "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true
     },
-    "ua-is-frozen": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ua-is-frozen/-/ua-is-frozen-0.1.2.tgz",
-      "integrity": "sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw=="
-    },
     "ua-parser-js": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
-      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
-      "requires": {
-        "detect-europe-js": "^0.1.2",
-        "is-standalone-pwa": "^0.1.1",
-        "ua-is-frozen": "^0.1.2"
-      }
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.35.tgz",
+      "integrity": "sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA=="
     },
     "unbox-primitive": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@hapi/bourne": "3.0.0",
     "js-md5": "0.7.3",
-    "ua-parser-js": "2.0.10"
+    "ua-parser-js": "1.0.35"
   },
   "devDependencies": {
     "@esm-bundle/chai": "4.3.4",


### PR DESCRIPTION
## Summary

ua-parser-js 2.x moved from MIT to **AGPL-3.0-or-later**, which is incompatible with this package's Apache-2.0 license and with downstream proprietary deployments. That is exactly why earlier 2.x dependabot PRs were closed without merging (#107: "The licence is changed in v2.*. We can't use it."). Merging #132 accidentally reversed that hold-back, and the auto-publish pipeline released npm versions 10.0.0–12.0.0 carrying the AGPL dependency while the package still declares Apache-2.0.

This PR reverts the bump, restoring the MIT 1.x line (1.0.35, the version in use before #132). The lockfile was reconciled with `npm install`; `npm ls ua-parser-js` resolves a single deduped 1.0.35.

Follow-ups tracked separately: a dependabot ignore rule for ua-parser-js >= 2.0.0 so the hold-back is enforced by config; npm deprecate + unpublish of the affected 10.x–12.x versions; and a fix for the version-bump workflow wording (its default word list substring-matches dependabot's update-type commit footer, which is what escalated 6.3.2 to 12.0.0 in one day).

## Test plan

- `npm run lint`, `npm test` (126/126 passed, 100% coverage), and `npm run build` all green locally after the revert.
- CI on this PR exercises the same three jobs.

> Merge note: please rebase-merge keeping the commit message as-is — it deliberately avoids the words that the version-bump action pattern-matches.