### PR TITLE
chore(deps): forbid dependabot from proposing ua-parser-js 2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,12 @@ updates:
       - "npm"
     commit-message:
       prefix: "build(deps)"
+    # ua-parser-js changed its license from MIT to AGPL-3.0-or-later in v2.0,
+    # which is incompatible with this package's Apache-2.0 license. Any bump
+    # past 1.x requires a license review first (see PRs #107, #132, #147).
+    ignore:
+      - dependency-name: "ua-parser-js"
+        versions: [">=2.0.0"]
     # Group updates to reduce PR noise
     groups:
       development-dependencies:


### PR DESCRIPTION
## Summary

ua-parser-js changed its license from MIT to **AGPL-3.0-or-later** in v2.0, which is incompatible with this package's Apache-2.0 license. The decision not to upgrade (#107) was until now enforced only by manually closing dependabot PRs — which is exactly how the 2.x bump slipped through in #132 and had to be reverted in #147.

This encodes the hold-back in `.github/dependabot.yml` via an `ignore` rule for `ua-parser-js >= 2.0.0`, with a comment explaining the reason so it survives team memory. Dependabot can still propose 1.x updates (1.0.41 is available, still MIT).

## Test plan

- YAML validated locally.
- After merge: dependabot's next weekly npm run should NOT open a ua-parser-js 2.x PR (can be checked immediately via the Dependabot tab → "Recent update jobs" → trigger a manual run).