### PR TITLE
ci(bump): stop dependency updates from escalating the package version

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -26,5 +26,12 @@ jobs:
         uses: "phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd"  # master
         with:
           commit-message: 'chore: bump version to {{version}}'
+          # The action's default word lists substring-match 'major'/'minor'
+          # anywhere in the commit message, and dependabot commit footers
+          # contain 'version-update:semver-major/-minor' — which escalated
+          # 6.3.2 to 12.0.0 (2026-07) and 2.8.2 to 6.0.0 (2025-10) from
+          # routine dependency updates. React only to deliberate markers.
+          major-wording: 'BREAKING CHANGE'
+          minor-wording: 'feat:,feat('
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

The `phips28/gh-action-bump-version` defaults substring-match its escalation words anywhere in the commit message. Dependabot's commit messages carry a footer of the form `update-type: version-update:semver-<level>`, which contains those words — so routine dependency merges escalated the package from 6.3.2 to 12.0.0 today, and the same accident took 2.8.2 to 6.0.0 on 2025-10-31 (that's where the 3.x–6.x numbers went).

This sets explicit word lists: a breaking release now requires the standard uppercase conventional-commits footer in the commit body, and a semver-middle release requires a conventional `feat` prefix. Everything else — dependency updates included — lands as a patch release.

## Test plan

- YAML validated locally.
- The commit message of this PR deliberately avoids both the old and the new trigger words; on merge it should produce a **patch** bump (12.0.2 → 12.0.3). That merge itself is the live test: on `push`, GitHub runs the workflow file from the pushed commit, so the new word lists apply immediately.

> Merge note: please rebase-merge keeping the commit message as-is.