### PR TITLE
ci(bump): source the version bump policy from the shared action

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -23,15 +23,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
       - name: "Automated Release"
-        uses: "phips28/gh-action-bump-version@215e27a882516826c59df7f09da8c67d5f375cbd"  # master
-        with:
-          commit-message: 'chore: bump version to {{version}}'
-          # The action's default word lists substring-match 'major'/'minor'
-          # anywhere in the commit message, and dependabot commit footers
-          # contain 'version-update:semver-major/-minor' — which escalated
-          # 6.3.2 to 12.0.0 (2026-07) and 2.8.2 to 6.0.0 (2025-10) from
-          # routine dependency updates. React only to deliberate markers.
-          major-wording: 'BREAKING CHANGE'
-          minor-wording: 'feat:,feat('
+        uses: "jitsi/gh-actions/npm-version-bump@066f0d506761c59a0ba4aa26c06468d265f07a3c"  # npm-version-bump/v1.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Follow-up to the wordings fix wave (jitsi/js-utils#149 and siblings): the escalation policy now lives in [`npm-version-bump` in jitsi/gh-actions](https://github.com/jitsi/gh-actions/tree/master/npm-version-bump) — a composite wrapper around the same pinned `phips28/gh-action-bump-version` with `major-wording: 'BREAKING CHANGE'` / `minor-wording: 'feat:,feat('` baked in (deliberately not overridable), a CI suite that replays the dependabot-footer incident as a permanent regression test, and dependabot proposing upstream updates in one reviewed place for the whole org.

This swaps the inline config for the shared action, pinned by SHA (npm-version-bump/v1.0.0).

## Test plan

- YAML validated locally.
- The shared action's own CI is green: composite-wiring smoke test + 7 replayed-event behavior cases.
- The commit message avoids all trigger words; the merge itself is the live test and should produce a patch bump.

> Merge note: please rebase-merge keeping the commit message as-is.